### PR TITLE
add sideEffects === false for webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
       "require": "./dist/blosc.cjs"
     }
   },
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "https://github.com/manzt/numcodecs.js.git"


### PR DESCRIPTION
I'm not very experienced with webpack, but I saw this [in the docs](https://webpack.js.org/guides/tree-shaking/) on tree-shaking:

> The new webpack 4 release expands on this capability with a way to provide hints to the compiler via the "sideEffects" package.json property to denote which files in your project are "pure" and therefore safe to prune if unused.

Since all exports (codecs) are side effect free in numcodecs, I added this to the repo's `package.json`. This seemed to fix #9, removing unused codecs from the final webpack bundle in my brief experimenting:

`index.js`
```javascript
import { Blosc } from 'numcodecs';

const codec = new Blosc();

```

`webpack.config.js`

```javascript
const path = require('path');

module.exports = {
  entry: 'index.js',
  output: {
    filename: 'bundle.js',
    path: path.resolve(__dirname, 'dist'),
  },
  mode: 'production',
  optimization: {
    minimize: false // just so I could inspect the bundled output
  }
}
```