### PR TITLE
Create generic codec constructor interface

### DIFF
--- a/src/blosc.ts
+++ b/src/blosc.ts
@@ -1,13 +1,20 @@
 import { initEmscriptenModule } from './utils';
 import blosc_codec, { BloscModule } from '../codecs/blosc/blosc_codec';
 import wasmSrc from '../codecs/blosc/blosc_codec.wasm';
-import type { Codec, CompressorConfig } from './utils';
+import type { Codec, CodecConstructor } from './utils';
 
 enum BloscShuffle {
   NOSHUFFLE = 0,
   SHUFFLE = 1,
   BITSHUFFLE = 2,
   AUTOSHUFFLE = -1,
+}
+
+interface BloscConfig {
+  blocksize?: number;
+  clevel?: number;
+  cname?: string;
+  shuffle?: BloscShuffle;
 }
 
 type BloscCompressionLevel = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
@@ -18,7 +25,7 @@ const COMPRESSORS = new Set(['blosclz', 'lz4', 'lz4hc', 'snappy', 'zlib', 'zstd'
 
 let emscriptenModule: Promise<BloscModule>;
 
-class Blosc implements Codec {
+const Blosc: CodecConstructor<BloscConfig> = class Blosc implements Codec {
   public static codecId = 'blosc';
   public static COMPRESSORS = [...COMPRESSORS];
   public static NOSHUFFLE = BloscShuffle.NOSHUFFLE;
@@ -53,10 +60,7 @@ class Blosc implements Codec {
     this.shuffle = shuffle;
   }
 
-  static fromConfig(
-    config: { blocksize?: number; clevel?: number; cname?: string; shuffle?: BloscShuffle } & CompressorConfig
-  ): Blosc {
-    const { blocksize, clevel, cname, shuffle } = config;
+  static fromConfig({ blocksize, clevel, cname, shuffle }: BloscConfig): Blosc {
     return new Blosc(clevel, cname, shuffle, blocksize);
   }
 
@@ -85,6 +89,6 @@ class Blosc implements Codec {
     }
     return result;
   }
-}
+};
 
 export default Blosc;

--- a/src/gzip.ts
+++ b/src/gzip.ts
@@ -1,9 +1,13 @@
 import pako from 'pako';
-import type { Codec, CompressorConfig } from './utils';
+import type { Codec, CodecConstructor } from './utils';
 
 type ValidGZipLevelSetting = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
 
-class GZip implements Codec {
+interface GZipConfig {
+  level?: number;
+}
+
+const GZip: CodecConstructor<GZipConfig> = class GZip implements Codec {
   public static codecId = 'gzip';
   public level: ValidGZipLevelSetting;
 
@@ -14,7 +18,7 @@ class GZip implements Codec {
     this.level = level as ValidGZipLevelSetting;
   }
 
-  static fromConfig({ level }: { level: number } & CompressorConfig): GZip {
+  static fromConfig({ level }: GZipConfig): GZip {
     return new GZip(level);
   }
 
@@ -31,6 +35,6 @@ class GZip implements Codec {
     }
     return uncompressed;
   }
-}
+};
 
 export default GZip;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export type { Codec, CompressorConfig } from './utils';
+export type { Codec, CodecConstructor } from './utils';
 export { default as GZip } from './gzip';
 export { default as Zlib } from './zlib';
 export { default as Blosc } from './blosc';

--- a/src/lz4.ts
+++ b/src/lz4.ts
@@ -1,14 +1,18 @@
 import { initEmscriptenModule } from './utils';
 import lz4_codec, { LZ4Module } from '../codecs/lz4/lz4_codec';
 import wasmSrc from '../codecs/lz4/lz4_codec.wasm';
-import type { Codec, CompressorConfig } from './utils';
+import type { Codec, CodecConstructor } from './utils';
 
 const DEFAULT_ACCELERATION = 1;
 const MAX_BUFFER_SIZE = 0x7e000000;
 
 let emscriptenModule: Promise<LZ4Module>;
 
-class LZ4 implements Codec {
+interface LZ4Config {
+  acceleration?: number;
+}
+
+const LZ4: CodecConstructor<LZ4Config> = class LZ4 implements Codec {
   public static codecId = 'lz4';
   public static DEFAULT_ACCELERATION = DEFAULT_ACCELERATION;
   public static max_buffer_size = MAX_BUFFER_SIZE;
@@ -22,7 +26,7 @@ class LZ4 implements Codec {
     this.acceleration = acceleration <= 0 ? DEFAULT_ACCELERATION : acceleration;
   }
 
-  static fromConfig({ acceleration }: { acceleration?: number } & CompressorConfig): LZ4 {
+  static fromConfig({ acceleration }: LZ4Config): LZ4 {
     return new LZ4(acceleration);
   }
 
@@ -61,6 +65,6 @@ class LZ4 implements Codec {
     }
     return result;
   }
-}
+};
 
 export default LZ4;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,11 @@
-export abstract class Codec {
-  static codecId: string;
-  abstract encode(data: Uint8Array): Uint8Array | Promise<Uint8Array>;
-  abstract decode(data: Uint8Array, out?: Uint8Array): Uint8Array | Promise<Uint8Array>;
+export interface CodecConstructor<T> {
+  fromConfig(config: T & { id: string }): Codec;
+  codecId: string;
 }
 
-export interface CompressorConfig {
-  id: string;
+export interface Codec {
+  encode(data: Uint8Array): Uint8Array | Promise<Uint8Array>;
+  decode(data: Uint8Array, out?: Uint8Array): Uint8Array | Promise<Uint8Array>;
 }
 
 const IS_NODE = typeof process !== 'undefined' && process.versions != null && process.versions.node != null;

--- a/src/zlib.ts
+++ b/src/zlib.ts
@@ -1,9 +1,13 @@
 import pako from 'pako';
-import type { Codec, CompressorConfig } from './utils';
+import type { Codec, CodecConstructor } from './utils';
 
 type ValidZlibLevelSetting = -1 | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
 
-class Zlib implements Codec {
+interface ZlibConfig {
+  level?: number;
+}
+
+const Zlib: CodecConstructor<ZlibConfig> = class Zlib implements Codec {
   public static codecId = 'zlib';
   public level: ValidZlibLevelSetting;
 
@@ -14,7 +18,7 @@ class Zlib implements Codec {
     this.level = level as ValidZlibLevelSetting;
   }
 
-  static fromConfig({ level }: { level: number } & CompressorConfig): Zlib {
+  static fromConfig({ level }: ZlibConfig): Zlib {
     return new Zlib(level);
   }
 
@@ -31,6 +35,6 @@ class Zlib implements Codec {
     }
     return uncompressed;
   }
-}
+};
 
 export default Zlib;

--- a/src/zstd.ts
+++ b/src/zstd.ts
@@ -1,14 +1,18 @@
 import { initEmscriptenModule } from './utils';
 import zstd_codec, { ZstdModule } from '../codecs/zstd/zstd_codec';
 import wasmSrc from '../codecs/zstd/zstd_codec.wasm';
-import type { Codec, CompressorConfig } from './utils';
+import type { Codec, CodecConstructor } from './utils';
 
 const DEFAULT_CLEVEL = 1;
 const MAX_CLEVEL = 22;
 
 let emscriptenModule: Promise<ZstdModule>;
 
-class Zstd implements Codec {
+interface ZstdConfig {
+  level?: number;
+}
+
+const Zstd: CodecConstructor<ZstdConfig> = class Zstd implements Codec {
   public static codecId = 'zstd';
   public static DEFAULT_CLEVEL = DEFAULT_CLEVEL;
   public static MAX_CLEVEL = MAX_CLEVEL;
@@ -21,7 +25,7 @@ class Zstd implements Codec {
     this.level = level;
   }
 
-  static fromConfig({ level }: { level?: number } & CompressorConfig): Zstd {
+  static fromConfig({ level }: ZstdConfig): Zstd {
     return new Zstd(level);
   }
 
@@ -47,7 +51,6 @@ class Zstd implements Codec {
     if (!emscriptenModule) {
       emscriptenModule = initEmscriptenModule(zstd_codec, wasmSrc);
     }
-
     const module = await emscriptenModule;
     const view = module.decompress(data);
     const result = new Uint8Array(view); // Copy view and free wasm memory
@@ -58,6 +61,6 @@ class Zstd implements Codec {
     }
     return result;
   }
-}
+};
 
 export default Zstd;


### PR DESCRIPTION
Previously the static constructor for each codec (`fromConfig`) was not type constrained. This PR adds a constraint where each Codec must implement both a static and instance interface: https://www.typescriptlang.org/docs/handbook/interfaces.html#difference-between-the-static-and-instance-sides-of-classes